### PR TITLE
fix: use full seconds when converting to duration

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -125,7 +125,7 @@ impl fmt::Display for TimeStamp {
 }
 impl From<TimeStamp> for Duration {
     fn from(ti: TimeStamp) -> Duration {
-        Duration::from_secs(ti.seconds() as u64)
+        Duration::from_secs(ti.seconds as u64)
             + Duration::from_millis(ti.frames() as u64 * 40 / 3)
     }
 }


### PR DESCRIPTION
I noticed that converting to `Duration` would leave off the minutes. Using the struct field `seconds` instead of the method `seconds()` correctly obtains the full amount of seconds.